### PR TITLE
fix cpu_buffer_values_ in 3D texture helper

### DIFF
--- a/include/mppi/utils/texture_helpers/three_d_texture_helper.cu
+++ b/include/mppi/utils/texture_helpers/three_d_texture_helper.cu
@@ -100,7 +100,7 @@ void ThreeDTextureHelper<DATA_T>::updateTexture(
     this->cpu_buffer_values_[index].resize(w * h * d);
     // copies values back to the buffer if it has been recently moved
     std::copy(this->cpu_values_[index].begin(), this->cpu_values_[index].end(),
-              this->cpu_buffers_values_[index].begin());
+              this->cpu_buffer_values_[index].begin());
   }
 
   // copy over values to cpu side holder


### PR DESCRIPTION
Typo fix of undefined cpu_buffers_values_ to cpu_buffer_values_ in 3D texture helper