### PR TITLE
Fix in RK4 integration

### DIFF
--- a/include/mppi/utils/numerical_integration.h
+++ b/include/mppi/utils/numerical_integration.h
@@ -22,7 +22,7 @@ void rk4integrate(DYN* dynamics, float dt, const Eigen::Ref<typename DYN::state_
   // dynamics->computeStateDeriv(x_k + k1 * dt / 2, u_k, k2);
   // dynamics->computeStateDeriv(x_k + k2 * dt / 2, u_k, k3);
   // dynamics->computeStateDeriv(x_k + k3 * dt, u_k, k4);
-  x_kp1 = x_k + (k1 + 2 * k2 + 2 * k3 + k4) * dt / 2;
+  x_kp1 = x_k + (k1 + 2 * k2 + 2 * k3 + k4) * dt / 6;
 }
 
 #endif  // MPPIGENERIC_NUMERICAL_INTEGRATION_H


### PR DESCRIPTION
RK4 integration given by:
![image](https://github.com/user-attachments/assets/7dc1c898-db70-4e5b-a06d-27e6f856aaac)
Ref: D. Kressner, Advanced Numerical Analysis, Lecture Notes, EPFL, 2015, p. 13/97. [Online]. Available: https://www.epfl.ch/labs/anchp/wp-content/uploads/2018/05/AdvancedNA2015.pdf