### PR TITLE
Update CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ endif()
 ####################################
 # Set up options for configuration #
 ####################################
-option(BUILD_TESTS "BUILD_TESTS" OFF)
-option(BUILD_EXAMPLES "BUILD_EXAMPLES" OFF)
+option(MPPI_BUILD_TESTS "Build unit tests." OFF)
+option(MPPI_BUILD_EXAMPLES "Build example code." OFF)
 option(MPPI_USE_CUDA_BARRIERS "Compile MPPI-Generic with cuda barrier support. Turn off for GPUs older than the 20 series." ON)
 option(MPPI_USE_CUDA_BARRIERS_COST "Compile MPPI-Generic with cuda barriers for cost-only kernels when general barrier support is enabled." OFF)
 option(MPPI_USE_CUDA_BARRIERS_DYN "Compile MPPI-Generic with cuda barriers for dynamics-only kernels when general barrier support is enabled." ON)
@@ -93,7 +93,7 @@ if (MPPI_USE_CUDA_BARRIERS)
   endif()
 endif()
 
-if (BUILD_TESTS OR BUILD_EXAMPLES)
+if (MPPI_BUILD_TESTS OR MPPI_BUILD_EXAMPLES)
     # find yaml-cpp
     find_package(yaml-cpp REQUIRED)
     include_directories(${YAML_CPP_INCLUDE_DIR})
@@ -184,10 +184,10 @@ install(FILES
   DESTINATION ${CMAKE_CONFIG_DEST}
 )
 
-if (BUILD_TESTS OR BUILD_EXAMPLES)
+if (MPPI_BUILD_TESTS OR MPPI_BUILD_EXAMPLES)
     add_subdirectory(src)
 endif()
-if (BUILD_EXAMPLES)
+if (MPPI_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
@@ -198,7 +198,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/
 ###################################################################
 # Add gtest
 ###################################################################
-if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND BUILD_TESTS)
+if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND MPPI_BUILD_TESTS)
   message(STATUS "Building MPPI Generic tests")
   enable_testing()
   ############################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(MPPI-Generic VERSION 0.9.0 LANGUAGES C CXX CUDA)
 
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-if (POLICY CMP0104)
+if (CMAKE_VERSION VERSION_LESS 3.24 AND POLICY CMP0104)
     cmake_policy(SET CMP0104 OLD)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ endif()
 option(BUILD_TESTS "BUILD_TESTS" OFF)
 option(BUILD_EXAMPLES "BUILD_EXAMPLES" OFF)
 option(MPPI_USE_CUDA_BARRIERS "Compile MPPI-Generic with cuda barrier support. Turn off for GPUs older than the 20 series." ON)
+option(MPPI_USE_CUDA_BARRIERS_COST "Compile MPPI-Generic with cuda barriers for cost-only kernels when general barrier support is enabled." OFF)
+option(MPPI_USE_CUDA_BARRIERS_DYN "Compile MPPI-Generic with cuda barriers for dynamics-only kernels when general barrier support is enabled." ON)
+option(MPPI_USE_CUDA_BARRIERS_ROLLOUT "Compile MPPI-Generic with cuda barriers for combined kernels when general barrier support is enabled." ON)
 option(MPPI_EXPORT_PACKAGE "Export this folder as the MPPI installation to the global CMake package repository" OFF)
 set(MPPI_CUDA_ARCH_LIST "" CACHE STRING "Specific CUDA Architectures to build for. Leave empty for automatic selection.")
 
@@ -76,6 +79,18 @@ endif()
 if (MPPI_USE_CUDA_BARRIERS)
   target_compile_definitions(${MPPI_HEADER_LIBRARY_NAME} INTERFACE
     CMAKE_USE_CUDA_BARRIERS)
+  if (MPPI_USE_CUDA_BARRIERS_DYN)
+    target_compile_definitions(${MPPI_HEADER_LIBRARY_NAME} INTERFACE
+      CMAKE_USE_CUDA_BARRIERS_DYN)
+  endif()
+  if (MPPI_USE_CUDA_BARRIERS_ROLLOUT)
+    target_compile_definitions(${MPPI_HEADER_LIBRARY_NAME} INTERFACE
+      CMAKE_USE_CUDA_BARRIERS_ROLLOUT)
+  endif()
+  if (MPPI_USE_CUDA_BARRIERS_COST)
+    target_compile_definitions(${MPPI_HEADER_LIBRARY_NAME} INTERFACE
+      CMAKE_USE_CUDA_BARRIERS_COST)
+  endif()
 endif()
 
 if (BUILD_TESTS OR BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,12 @@ if (CMAKE_VERSION VERSION_LESS 3.12)
 else()
   cmake_minimum_required(VERSION 3.8...3.24)
 endif()
-project(MPPI-Generic VERSION 0.9.0 LANGUAGES C CXX CUDA)
 
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
 if (CMAKE_VERSION VERSION_LESS 3.24 AND POLICY CMP0104)
     cmake_policy(SET CMP0104 OLD)
 endif()
+project(MPPI-Generic VERSION 0.9.0 LANGUAGES C CXX CUDA)
 
 ####################################
 # Set up options for configuration #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 ####################################
 option(MPPI_BUILD_TESTS "Build unit tests." OFF)
 option(MPPI_BUILD_EXAMPLES "Build example code." OFF)
+option(MPPI_CCACHE_DISABLE "Disable using ccache (when available) to potentially speed up repeated builds" OFF)
 option(MPPI_USE_CUDA_BARRIERS "Compile MPPI-Generic with cuda barrier support. Turn off for GPUs older than the 20 series." ON)
 option(MPPI_USE_CUDA_BARRIERS_COST "Compile MPPI-Generic with cuda barriers for cost-only kernels when general barrier support is enabled." OFF)
 option(MPPI_USE_CUDA_BARRIERS_DYN "Compile MPPI-Generic with cuda barriers for dynamics-only kernels when general barrier support is enabled." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
+if (CMAKE_VERSION VERSION_LESS 3.12)
+  cmake_minimum_required(VERSION 3.8)
+else()
+  cmake_minimum_required(VERSION 3.8...3.24)
+endif()
 project(MPPI-Generic VERSION 0.9.0 LANGUAGES C CXX CUDA)
 
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
@@ -11,7 +15,7 @@ endif()
 ####################################
 option(MPPI_BUILD_TESTS "Build unit tests." OFF)
 option(MPPI_BUILD_EXAMPLES "Build example code." OFF)
-option(MPPI_CCACHE_DISABLE "Disable using ccache (when available) to potentially speed up repeated builds" OFF)
+option(MPPI_USE_CCACHE "Use ccache (when available) to potentially speed up repeated builds" ON)
 option(MPPI_USE_CUDA_BARRIERS "Compile MPPI-Generic with cuda barrier support. Turn off for GPUs older than the 20 series." ON)
 option(MPPI_USE_CUDA_BARRIERS_COST "Compile MPPI-Generic with cuda barriers for cost-only kernels when general barrier support is enabled." OFF)
 option(MPPI_USE_CUDA_BARRIERS_DYN "Compile MPPI-Generic with cuda barriers for dynamics-only kernels when general barrier support is enabled." ON)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 MPPI-Generic is a C++/CUDA header-only library implementation of Model Predictive Path Integral Control (MPPI) by [Williams et al.](https://ieeexplore.ieee.org/document/8558663)
 
 ## Citation
-If you use this library for research purposes, please cite the following paper:
+If you use this library for research purposes, please cite the following [paper](https://arxiv.org/abs/2409.07563):
 ```
-@misc{vlahov2024mppigenericcudalibrarystochastic,
-      title={MPPI-Generic: A CUDA Library for Stochastic Optimization},
+@misc{vlahov2024mppi,
+      title={MPPI-Generic: A CUDA Library for Stochastic Trajectory Optimization},
       author={Bogdan Vlahov and Jason Gibson and Manan Gandhi and Evangelos A. Theodorou},
       year={2024},
       eprint={2409.07563},
@@ -44,19 +44,19 @@ Note: If using Pop!\_OS you can `sudo apt install system76-cuda` instead of inst
 ## Download the repo
 ```bash
 cd /path/to/repos
-git clone https://github.gatech.edu/ACDS/MPPI-Generic.git
+git clone https://github.com/ACDSLab/MPPI-Generic.git
 cd MPPI-Generic
 git submodule update --init --recursive
 ```
 ## Building MPPI-Generic with tests
 
 The default is to build the library with tests OFF.
-If you would like to turn on the tests when building, pass the flag `-DBUILD_TESTS=ON` when configuring cmake.
+If you would like to turn on the tests when building, pass the flag `-DMPPI_BUILD_TESTS=ON` when configuring cmake.
 
 ```bash
 mkdir build
 cd build
-cmake -DBUILD_TESTS=ON ..
+cmake -DMPPI_BUILD_TESTS=ON ..
 make
 make test
 ```

--- a/cmake/MPPIGenericToolsConfig.cmake
+++ b/cmake/MPPIGenericToolsConfig.cmake
@@ -13,6 +13,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Look for ccache to potentially speed up repeated compilations
+find_program(CCACHE_PROGRAM ccache)
+if (CCACHE_PROGRAM AND NOT MPPI_CCACHE_DISABLE)
+  message(STATUS "Using ccache to speed up repeated builds")
+  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+  set(CMAKE_CUDA_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+elseif(NOT CCACHE_PROGRAM AND NOT MPPI_CCACHE_DISABLE)
+  message(STATUS "ccache not found. Using ccache can speed up repeated builds.")
+endif()
+
 # Add debug flags so cuda-gdb can be used to stop inside a kernel.
 # NOTE: You may have to run make multiple times for it to compile successfully.
 set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G --keep")

--- a/cmake/MPPIGenericToolsConfig.cmake
+++ b/cmake/MPPIGenericToolsConfig.cmake
@@ -15,12 +15,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Look for ccache to potentially speed up repeated compilations
 find_program(CCACHE_PROGRAM ccache)
-if (CCACHE_PROGRAM AND NOT MPPI_CCACHE_DISABLE)
+if (CCACHE_PROGRAM AND NOT MPPI_USE_CCACHE)
   message(STATUS "Using ccache to speed up repeated builds")
   set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
   set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
   set(CMAKE_CUDA_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
-elseif(NOT CCACHE_PROGRAM AND NOT MPPI_CCACHE_DISABLE)
+elseif(NOT CCACHE_PROGRAM AND NOT MPPI_USE_CCACHE)
   message(STATUS "ccache not found. Using ccache can speed up repeated builds.")
 endif()
 

--- a/cmake/MPPIGenericToolsConfig.cmake
+++ b/cmake/MPPIGenericToolsConfig.cmake
@@ -17,37 +17,63 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # NOTE: You may have to run make multiple times for it to compile successfully.
 set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G --keep")
 set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO} --generate-line-info")
-# required for curand on some systems
-find_package(CUDA REQUIRED)
 
-if(NOT ${CUDA_curand_LIBRARY} MATCHES "NOTFOUND")
-    set(CURAND_LIBRARY ${CUDA_curand_LIBRARY})
+# Generate variable for all the extra cuda libraries we use
+set(MPPI_GENERIC_CUDA_EXTRA_LIBS "")
+if (CMAKE_VERSION VERSION_LESS 3.24)
+  # required for curand on some systems
+  find_package(CUDA REQUIRED)
+
+  if(${CUDA_curand_LIBRARY} MATCHES "NOTFOUND")
+      message(ERROR "cuRAND library not found.")
+  endif()
+
+  list(APPEND MPPI_GENERIC_CUDA_EXTRA_LIBS ${CUDA_curand_LIBRARY} ${CUDA_CUFFT_LIBRARIES})
+else()
+  find_package(CUDAToolkit REQUIRED)
+  set(CUDA_VERSION ${CUDAToolkit_VERSION})
+  list(APPEND MPPI_GENERIC_CUDA_EXTRA_LIBS CUDA::curand CUDA::cufft)
 endif()
 
 # Generate name for MPPI header library
 set(MPPI_HEADER_LIBRARY_NAME mppi_header_only_lib)
 
-# Generate variable for all the extra cuda libraries we use
-set(MPPI_GENERIC_CUDA_EXTRA_LIBS "")
-list(APPEND MPPI_GENERIC_CUDA_EXTRA_LIBS ${CUDA_curand_LIBRARY} ${CUDA_CUFFT_LIBRARIES})
-
 set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 
-# Autodetect Cuda Architecture on system and add to executables
-# More info for autodetection:
-# https://stackoverflow.com/questions/35485087/determining-which-gencode-compute-arch-values-i-need-for-nvcc-within-cmak
-if (NOT DEFINED MPPI_ARCH_FLAGS)
-  CUDA_SELECT_NVCC_ARCH_FLAGS(MPPI_ARCH_FLAGS ${CUDA_ARCH_LIST})
+#################################################################
+# Autodetect Cuda Architecture on system and add to executables #
+#################################################################
+# CMake 3.24 added '-arch=native' support so until that version, we need to use the old method of autodetection
+if (CMAKE_VERSION VERSION_LESS 3.24)
+  # Don't rerun autodetection when used as a submodule
+  if (NOT DEFINED MPPI_ARCH_FLAGS)
+    # More info for autodetection:
+    # https://stackoverflow.com/questions/35485087/determining-which-gencode-compute-arch-values-i-need-for-nvcc-within-cmak
+    CUDA_SELECT_NVCC_ARCH_FLAGS(MPPI_ARCH_FLAGS ${MPPI_CUDA_ARCH_LIST})
 
-  if (MPPI_ARCH_FLAGS STREQUAL "")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -maxrregcount=32 -arch=sm_35")
+    if (MPPI_ARCH_FLAGS STREQUAL "")
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -maxrregcount=32 -arch=sm_35")
+    else()
+      string(REGEX REPLACE "-gencode;arch" "-gencode=arch" MPPI_ARCH_FLAGS "${MPPI_ARCH_FLAGS}")
+      string(REPLACE ";" " " MPPI_ARCH_FLAGS "${MPPI_ARCH_FLAGS}")
+      # string(REGEX REPLACE "^-gencode=arch" "-arch" MPPI_ARCH_FLAGS "${MPPI_ARCH_FLAGS}")
+      message(STATUS "CUDA Architecture(s): ${MPPI_ARCH_FLAGS}")
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${MPPI_ARCH_FLAGS}")
+    endif()
   else()
-    string(REGEX REPLACE "-gencode;arch" "-gencode=arch" MPPI_ARCH_FLAGS "${MPPI_ARCH_FLAGS}")
-    string(REPLACE ";" " " MPPI_ARCH_FLAGS "${MPPI_ARCH_FLAGS}")
-    # string(REGEX REPLACE "^-gencode=arch" "-arch" MPPI_ARCH_FLAGS "${MPPI_ARCH_FLAGS}")
-    message(STATUS "Additional Architectures: ${MPPI_ARCH_FLAGS}")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${MPPI_ARCH_FLAGS}")
+    message(STATUS "Autodetection already ran and found ${MPPI_ARCH_FLAGS}.")
   endif()
 else()
-  message(STATUS "Autodetection already ran and found ${MPPI_ARCH_FLAGS}.")
+  # Don't rerun autodetection when used as a submodule
+  if (NOT DEFINED MPPI_ARCH_FLAGS)
+    if ("${MPPI_CUDA_ARCH_LIST}" STREQUAL "")
+      set(CMAKE_CUDA_ARCHITECTURES native)
+    else()
+      set(CMAKE_CUDA_ARCHITECTURES "${MPPI_CUDA_ARCH_LIST}")
+    endif()
+    set(MPPI_ARCH_FLAGS "${CMAKE_CUDA_ARCHITECTURES}")
+    message(STATUS "CUDA Architecture(s): ${CMAKE_CUDA_ARCHITECTURES}")
+  else()
+    message(STATUS "Autodetection already ran and found ${MPPI_ARCH_FLAGS}.")
+  endif()
 endif()

--- a/include/mppi/core/mppi_common.cu
+++ b/include/mppi/core/mppi_common.cu
@@ -4,14 +4,21 @@
 #include <mppi/utils/math_utils.h>
 #include <mppi/utils/cuda_math_utils.cuh>
 
-// CUDA barriers were first implemented in Cuda 11
+// CUDA barriers were first implemented in CUDA 11
 #if defined(CMAKE_USE_CUDA_BARRIERS) && defined(CUDART_VERSION) && CUDART_VERSION > 11000
 #include <cuda/barrier>
 using barrier = cuda::barrier<cuda::thread_scope_block>;
 
+// Turn on/off various CUDA barriers from CMake configuration
+#ifdef CMAKE_USE_CUDA_BARRIERS_DYN
 #define USE_CUDA_BARRIERS_DYN
-// #define USE_CUDA_BARRIERS_COST
+#endif
+#ifdef CMAKE_USE_CUDA_BARRIERS_COST
+#define USE_CUDA_BARRIERS_COST
+#endif
+#ifdef CMAKE_USE_CUDA_BARRIERS_ROLLOUT
 #define USE_CUDA_BARRIERS_ROLLOUT
+#endif
 #endif
 
 #include <cooperative_groups.h>


### PR DESCRIPTION
This pull request updates MPPI-Generic's CMake configuration in the following ways:

* Update CMake minimum version to show compliance with CMake 3.24 in MPPI-Generic and its submodule cnpy
* Change CMake options BUILD_TESTS/EXAMPLES to MPPI_BUILD_TESTS/EXAMPLES to avoid conflation with other libraries' options
* Add CMake options to turn CUDA barriers on/off in specific kernels. We have found in most systems, disabling the cost kernel's use of CUDA barriers would mean faster optimal control computation and so it is set to off by default.
* Update the GPU autodetection to use CMake's new `CMAKE_CUDA_ARCHITECTURES` in versions of CMake that support native (>=3.24). The previous GPU autodetection system (using the deprecated `FindCUDA` module) is used for CMake versions before that.
* Add support for `ccache`

I have tested this with CMake 3.16 (Ubuntu 20.04), 3.22 (Ubuntu 22.04), 3.28 (Ubuntu 24.04), and 3.31 (local install) and it should not produce any CMake warnings or errors.

Should also resolve the original issue in #19 as well.