### PR TITLE
Fix LN Variance in Log-MPPI

### DIFF
--- a/include/mppi/sampling_distributions/nln/nln.cu
+++ b/include/mppi/sampling_distributions/nln/nln.cu
@@ -97,7 +97,8 @@ void NLN_NOISE::calculateLogMeanAndVariance()
   {
     normal_variance = this->params_.std_dev[i] * this->params_.std_dev[i];
     log_noise_mean_[i] = expf(0.5 * normal_variance);
-    log_variance = expf(normal_variance) * expf(normal_variance - 1.0f);
+    float exp_normal_variance = expf(normal_variance);
+    log_variance = exp_normal_variance * (exp_normal_variance - 1.0f);
     log_noise_std_dev_[i] = sqrtf(log_variance);
   }
 }


### PR DESCRIPTION
fix log mppi LN variance.

In the [Log-MPPI paper](https://arxiv.org/pdf/2203.16599) eq6, the LN variance is subtlely different.

<img width="429" height="44" alt="image" src="https://github.com/user-attachments/assets/4b0bb32a-9b5b-4023-9a88-a9b1db814f55" />

Also found in the [other log mppi repo](https://github.com/IhabMohamed/log-MPPI_ros/blob/ddc71ea1d48a5143dc54a668400758d2d168ea27/mppi_control/scripts/mppi_control/utils.py#L359) that this code referenced.