### PR TITLE
Fix some unit tests hanging indefinitely

### DIFF
--- a/tests/dynamics/racer_dubins_elevation_lstm_steering_model_test.cu
+++ b/tests/dynamics/racer_dubins_elevation_lstm_steering_model_test.cu
@@ -561,7 +561,7 @@ TEST_F(RacerDubinsElevationLSTMSteeringTest, TestStep)
 
 TEST_F(RacerDubinsElevationLSTMSteeringTest, TestStepGPUvsCPUNoNetwork)
 {
-  const int num_rollouts = 1000;
+  const int num_rollouts = 1024;
   const float dt = 0.1f;
   CudaCheckError();
   using DYN = RacerDubinsElevationLSTMSteering;
@@ -664,7 +664,7 @@ TEST_F(RacerDubinsElevationLSTMSteeringTest, TestStepGPUvsCPUNoNetwork)
 
 TEST_F(RacerDubinsElevationLSTMSteeringTest, TestStepGPUvsCPU)
 {
-  const int num_rollouts = 60;
+  const int num_rollouts = 64;
   const float dt = 0.1f;
   CudaCheckError();
   using DYN = RacerDubinsElevationLSTMSteering;
@@ -720,7 +720,7 @@ TEST_F(RacerDubinsElevationLSTMSteeringTest, TestStepGPUvsCPUReverse)
 {
   using DYN = RacerDubinsElevationLSTMSteering;
 
-  const int num_rollouts = 1000;
+  const int num_rollouts = 1024;
   const float dt = 0.1f;
   CudaCheckError();
   RacerDubinsElevationLSTMSteering dynamics = RacerDubinsElevationLSTMSteering(mppi::tests::steering_lstm);
@@ -778,7 +778,7 @@ TEST_F(RacerDubinsElevationLSTMSteeringTest, compareToElevationWithoutSteering)
   using DYN = RacerDubinsElevationLSTMSteering;
   using DYN_PARAMS = DYN::DYN_PARAMS_T;
 
-  const int num_rollouts = 1000;
+  const int num_rollouts = 1024;
   const float dt = 0.1f;
   CudaCheckError();
   auto dynamics = RacerDubinsElevationLSTMSteering(3, 20, init_output_layers, 4, 4, output_layers, 11);

--- a/tests/include/kernel_tests/dynamics/dynamics_generic_kernel_tests.cu
+++ b/tests/include/kernel_tests/dynamics/dynamics_generic_kernel_tests.cu
@@ -374,6 +374,12 @@ void launchStepTestKernel(DYNAMICS_T& dynamics, std::vector<std::array<float, DY
     std::cerr << "Num States doesn't match num next_states" << std::endl;
     return;
   }
+  if (state.size() % dim_x != 0)
+  {
+    std::cerr << "Num States needs be evenly divisible by dim_x: " << state.size()
+              << " state queries, " << dim_x << " parallelizable threads per block" << std::endl;
+    return;
+  }
   int count = state.size();
   float* state_d;
   float* control_d;
@@ -433,7 +439,7 @@ void checkGPUComputationStep(DYN_T& dynamics, float dt, int max_y_dim, int x_dim
   dynamics.GPUSetup();
   CudaCheckError();
 
-  const int num_points = 1000;
+  const int num_points = 1024;
   Eigen::Matrix<float, DYN_T::CONTROL_DIM, num_points> control_trajectory;
   control_trajectory = Eigen::Matrix<float, DYN_T::CONTROL_DIM, num_points>::Random();
   Eigen::Matrix<float, DYN_T::STATE_DIM, num_points> state_trajectory;


### PR DESCRIPTION
I'm going through the various unit tests that are failing and trying to fix them. I discovered that at some point, we began to have dynamics unit tests that would never finish running.

Dynamics that have neural networks have a `__syncthreads()` call in them at some point due to internal neural network computations. The StepTestKernel used in the dynamics unit tests has `if` statements which reduce the threads to the number of queries.
```cuda
if (thread_x < num)
{
  ...
}
```
 If the number of x threads doesn't evenly divide the number of queries, this would cause not all threads to reach `__syncthreads()`. This commit makes sure that all the offending unit tests are fixed to have even division.
 
 Further work is still needed to fix the failing unit tests but this at least causes them all to finish running.